### PR TITLE
fix: returning back to the prev param req not requiring userName. And…

### DIFF
--- a/api/accessTokenToHeader.js
+++ b/api/accessTokenToHeader.js
@@ -16,7 +16,6 @@ async function accessTokenToHeader(reqAccessToken, gitHubUserName){
         }
         if(userInfo){
             accessToken = decrypt(userInfo.accessToken)
-            console.log(accessToken)
         }
         if(accessToken === ""){
             accessToken =  process.env.GITHUB_TEMP_ACCESS_TOKEN;

--- a/api/calculateMergeDuration.js
+++ b/api/calculateMergeDuration.js
@@ -111,9 +111,9 @@ router.get("/:userName/:owner/:reqrepo/single_pull/:pullnumber", async (req, res
  * averageDuration - calculated average duration in milliseconds
  */
 
-router.get("/:userName/:owner/:reqrepo/pull_data", async (req, res, next) => {
-    const { userName, owner, reqrepo } = req.params;
-    const header = accessTokenToHeader(req.headers.authorization, userName);
+router.get("/:owner/:reqrepo/pull_data", async (req, res, next) => {
+    const { owner, reqrepo } = req.params;
+    const header = accessTokenToHeader(req.headers.authorization, owner);
     try {
         const response = await axios.get(`https://api.github.com/repos/${owner}/${reqrepo}/pulls?state=all`, {
             headers : header

--- a/api/followOnCommit.js
+++ b/api/followOnCommit.js
@@ -26,9 +26,9 @@ let header = "";
  * return 
  * pull request data with the commit count. The count is accessible at followOnCommitCount 
  */
-router.get("/:userName/:owner/:reqrepo/pull_data", async (req, res, next) => {
-    const { userName, owner, reqrepo } = req.params;
-    header = accessTokenToHeader(req.headers.authorization, userName);
+router.get("/:owner/:reqrepo/pull_data", async (req, res, next) => {
+    const { owner, reqrepo } = req.params;
+    header = accessTokenToHeader(req.headers.authorization, owner);
     try{
         const responseWithCalculatedData = await calculateCommitCount(owner, reqrepo);
         responseWithCalculatedData

--- a/api/prIterationTime.js
+++ b/api/prIterationTime.js
@@ -26,9 +26,9 @@ let header = ""
  * return 
  * percentage : average of iteration time 
  */
-router.get("/:userName/:owner/:reqrepo", async (req, res, next) =>{
-    const {userName, owner, reqrepo} = req.params;
-    header = accessTokenToHeader(req.headers.authorization, userName);
+router.get("/:owner/:reqrepo", async (req, res, next) =>{
+    const {owner, reqrepo} = req.params;
+    header = accessTokenToHeader(req.headers.authorization, owner);
     try {
         const pullRequestData = await fetchPullRequests(owner, reqrepo);
         if(!pullRequestData) res.status(400).send("error in fetching pull request");

--- a/api/repo.js
+++ b/api/repo.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const axios = require("axios");
 const { Repo, User } = require("../db/models");
 const {accessTokenToHeader} = require("./accessTokenToHeader");
-console.log("here");
 /**
  * get all the repo which are owned by username
  * params
@@ -17,7 +16,6 @@ router.get("/:username", async (req, res, next) => {
         const allRepos = await axios.get(`https://api.github.com/users/${githubUser}/repos`,{
             headers : header
         });
-        console.log(header);
         const simplifiedRepos = allRepos.data.map(repo => ({
             id: repo.id,
             name: repo.name, 
@@ -59,10 +57,9 @@ router.get("/:owner/:reqrepo", async (req, res, next) => {
  * owner - repo owner
  * reqrepo - name of the repo
  */
-router.get("/:user/:owner/:reqrepo/pulls", async (req, res, next) => {
+router.get("/:owner/:reqrepo/pulls", async (req, res, next) => {
     const { owner, reqrepo } = req.params;
-    const { user } = req.params;
-    const header = accessTokenToHeader(req.headers.authorization, user);
+    const header = accessTokenToHeader(req.headers.authorization, owner);
     try{
         const pulls = await axios.get(`https://api.github.com/repos/${owner}/${reqrepo}/pulls?state=all`, {
             headers : header
@@ -83,10 +80,9 @@ router.get("/:user/:owner/:reqrepo/pulls", async (req, res, next) => {
  * reqrepo - name of the repo
  * pullnumber - the number of the PR
  */
-router.get("/:user/:owner/:reqrepo/pulls/:pullnumber", async (req, res, next) => {
+router.get("/:owner/:reqrepo/pulls/:pullnumber", async (req, res, next) => {
     const { owner, reqrepo, pullnumber } = req.params;
-    const { user } = req.params;
-    const header = accessTokenToHeader(req.headers.authorization, user);
+    const header = accessTokenToHeader(req.headers.authorization, owner);
     try{
         const pull = await axios.get(`https://api.github.com/repos/${owner}/${reqrepo}/pulls/${pullnumber}`,{
             headers : header

--- a/api/responsiveness.js
+++ b/api/responsiveness.js
@@ -31,9 +31,9 @@ let header = "";
  * return
  * pull request data with the calculated duration. The duration is accessible at responsivenessData
  */
-router.get("/:userName/:owner/:reqrepo", async (req, res, next) => {
-    const { owner, reqrepo, userName } = req.params;
-    header = accessTokenToHeader(req.headers.authorization, userName);
+router.get("/:owner/:reqrepo", async (req, res, next) => {
+    const { owner, reqrepo} = req.params;
+    header = accessTokenToHeader(req.headers.authorization, owner);
     try {
         const responseWithCalculatedData = await calculateResponsiveness(owner, reqrepo);
         responseWithCalculatedData

--- a/api/timeToFirstComment.js
+++ b/api/timeToFirstComment.js
@@ -26,9 +26,9 @@ let header = "";
  * return
  * pull request data with the calculated duration. The duration is accessible at timeToFirstComment
  */
-router.get("/:userName/:owner/:reqrepo/pull_data", async (req, res, next) => {
-    const { owner, reqrepo, userName } = req.params;
-    header = accessTokenToHeader(req.headers.authorization, userName);
+router.get("/:owner/:reqrepo/pull_data", async (req, res, next) => {
+    const { owner, reqrepo } = req.params;
+    header = accessTokenToHeader(req.headers.authorization, owner);
     try {
         const responseWithCalculatedData = await calculateTimeToFirstCommit(owner, reqrepo);
         responseWithCalculatedData

--- a/api/unreviewedPRs.js
+++ b/api/unreviewedPRs.js
@@ -26,9 +26,9 @@ let header = ""
  * return 
  * percentage : percentage of unreviewed pull requests
  */
-router.get("/:userName/:owner/:reqrepo", async (req, res, next) => {
-    const { owner, reqrepo, userName } = req.params;
-    header = accessTokenToHeader(req.headers.authorization, userName);
+router.get("/:owner/:reqrepo", async (req, res, next) => {
+    const { owner, reqrepo } = req.params;
+    header = accessTokenToHeader(req.headers.authorization, owner);
     try{
 
         const pullRequestsData = await fetchPullRequests(owner, reqrepo);


### PR DESCRIPTION
… the accessTokenToHeader will called with the owner as the parameter instead of the userName